### PR TITLE
Fixed typo auxilliary to auxiliary in shell/desc.json

### DIFF
--- a/algorithm/sorting/shell/desc.json
+++ b/algorithm/sorting/shell/desc.json
@@ -2,7 +2,7 @@
   "Shellsort": "Shellsort, also known as Shell sort or Shell's method, is an in-place comparison sort. It can be seen as either a generalization of sorting by exchange (bubble sort) or sorting by insertion (insertion sort). The method starts by sorting pairs of elements far apart from each other, then progressively reducing the gap between elements to be compared.",
   "Complexity": {
     "time": "best $O(n \\, log \\, n)$, average - depends on 'gap sequence'",
-    "space": "worst $O(n)$ total, $O(1)$ auxilliary"
+    "space": "worst $O(n)$ total, $O(1)$ auxiliary"
   },
   "References": [
     "<a href='https://en.wikipedia.org/wiki/Shellsort'>Wikipedia</a>"


### PR DESCRIPTION
Fixed Typo auxilliary to auxiliary. (one 'l')