### PR TITLE
fix vscode error message: "Experimental support for decorators"

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
Fix the vs-code error message:

![image](https://user-images.githubusercontent.com/3584317/58794112-1b70a580-8600-11e9-971e-31637e5efa61.png)

    Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option to remove this warning

