### PR TITLE
Add scrollbars to algorithms menu and visualization viewer

### DIFF
--- a/src/frontend/components/Navigator/stylesheet.scss
+++ b/src/frontend/components/Navigator/stylesheet.scss
@@ -4,6 +4,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow-y : auto;
 
   .search_bar_container {
     height: $line-height;

--- a/src/frontend/components/ResizableContainer/index.jsx
+++ b/src/frontend/components/ResizableContainer/index.jsx
@@ -48,6 +48,7 @@ class ResizableContainer extends React.Component {
         elements.push(
           <div key={i} className={classes(styles.wrapper)} style={{
             flexGrow: weights[i] / totalWeight,
+            overflowY: 'auto',
           }}>
             {child}
           </div>,

--- a/src/frontend/components/VisualizationViewer/stylesheet.scss
+++ b/src/frontend/components/VisualizationViewer/stylesheet.scss
@@ -5,4 +5,5 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  overflow-y: auto;
 }


### PR DESCRIPTION
I added scrollbars to the algorithms menu and the visualization viewer. It does scroll when it is on the main page with the Markdown file, but I may need some help to understand exactly how you'd want the scrolling to work with the visualizations. I'm new so I'm not entirely sure if those are the tracers.
Fixes #248 
I can also post a screen recording of a demo of the scrollbars if wanted.