### PR TITLE
Fix errors when resizing panels horizontally.

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -206,7 +206,7 @@ class App extends BaseComponent {
 
   handleChangeWorkspaceWeights(workspaceWeights) {
     this.setState({ workspaceWeights });
-    this.codeEditorRef.current.getWrappedInstance().handleResize();
+    this.codeEditorRef.current.handleResize();
   }
 
   toggleNavigatorOpened(navigatorOpened = !this.state.workspaceVisibles[0]) {

--- a/src/components/CodeEditor/index.js
+++ b/src/components/CodeEditor/index.js
@@ -16,7 +16,7 @@ class CodeEditor extends React.Component {
   }
 
   handleResize() {
-    this.aceEditorRef.current.getWrappedInstance().resize();
+    this.aceEditorRef.current.resize();
   }
 
   render() {


### PR DESCRIPTION
Closes #264

getWrappedInstance() is no longer necessary.

If {forwardRef : true} has been passed to connect, adding a ref to the connected wrapper component will actually return the instance of the wrapped component.